### PR TITLE
Add selected_acronyms and selected_allen_ids traits

### DIFF
--- a/ccfwidget/allen_id_label.py
+++ b/ccfwidget/allen_id_label.py
@@ -1,0 +1,33 @@
+__all__ = ['labels_for_allen_id']
+
+import urllib.request
+import json
+
+from .structure_graph import allen_id_to_tree_node
+
+from IPython.core.debugger import set_trace
+
+# Todo: Use AWS store after Scott / Lydia upload
+with urllib.request.urlopen("https://thewtex.github.io/allen-ccf-itk-vtk-zarr/allen_id_to_label.json") as url:
+    allen_id_to_label_str_keys = json.loads(url.read().decode())
+allen_id_to_label = { int(k): v for k,v in allen_id_to_label_str_keys.items() }
+
+def labels_for_allen_id_internal(allen_id, labels):
+    node = allen_id_to_tree_node[allen_id]
+    if len(node.children) == 0:
+        if node.allen_id in allen_id_to_label:
+            labels.append(allen_id_to_label[node.allen_id])
+    else:
+        for child in node.children:
+            labels_for_allen_id_internal(child.allen_id, labels)
+    return labels
+
+labels_for_allen_id_cache = dict()
+def labels_for_allen_id(allen_id):
+    if allen_id in labels_for_allen_id_cache:
+        return labels_for_allen_id_cache[allen_id]
+    else:
+        labels = []
+        labels_for_allen_id_internal(allen_id, labels)
+        labels_for_allen_id_cache[allen_id] = labels
+        return labels

--- a/ccfwidget/widget_ccf.py
+++ b/ccfwidget/widget_ccf.py
@@ -131,7 +131,7 @@ class CCFWidget(HBox):
 
     def _ipytree_on_selected_change(self, change):
         allen_ids = [node.allen_id for node in self.tree_widget.selected_nodes]
-        if not self._validating_tree:
+        if not self._validating_tree and not self._validating_allen_ids and not self._validating_acronyms:
             self.selected_allen_ids = allen_ids
         self.tree_widget.layout.width = '40%'
 

--- a/ccfwidget/widget_ccf.py
+++ b/ccfwidget/widget_ccf.py
@@ -2,16 +2,20 @@ __all__ = ['CCFWidget']
 
 from fsspec.implementations.http import HTTPFileSystem
 import json
-from ipywidgets import HBox, VBox, register, link, RadioButtons, Checkbox
+from ipywidgets import HBox, VBox, register, link, RadioButtons, Checkbox, Output
 import itk
 from itkwidgets import view
 import numpy as np
+from traitlets import CFloat, CInt, List, Unicode, validate
 import xarray as xr
 import zarr
 import urllib.request
 
 from .ipytree_widget import IPyTreeWidget
-from .structure_graph import structure_graph, acronym_to_allen_id
+from .structure_graph import acronym_to_allen_id, allen_id_to_acronym, structure_graph
+from .allen_id_label import labels_for_allen_id
+
+from IPython.core.debugger import set_trace
 
 _image_fs = HTTPFileSystem()
 # Todo: Use AWS store after Scott / Lydia upload
@@ -32,6 +36,12 @@ class CCFWidget(HBox):
     """A Jupyter widget for the Allen Common Coordinate Framework (CCF)
     Mouse Brain Atlas."""
 
+    off_weight = 0.05
+    on_weight = 1.0
+
+    selected_acronyms = List(trait=Unicode(), help='Structure Allen Ids to highlight.')
+    selected_allen_ids = List(trait=CInt(), help='Structure Allen Ids to highlight.')
+
     def __init__(self, tree=None, rotate=False, **kwargs):
         self._image = itk.image_from_xarray(_image_da)
         self._label_map = itk.image_from_xarray(_label_map_da)
@@ -45,35 +55,115 @@ class CCFWidget(HBox):
            'width': 0.1,
            'xBias': 0,
            'yBias': 0}]]
-        camera = np.array([[-1.9388698e+02, -6.0452373e+03,  2.0659662e+04],
-                           [ 6.7440376e+03,  4.0228694e+03,  6.0504180e+03],
-                           [ 4.6800941e-01, -8.1573588e-01, -3.3991495e-01]], dtype=np.float32)
+        opacity_gaussians = [[{'position': 0.32816358024691356,
+           'height': 1,
+           'width': 0.29048611111111106,
+           'xBias': 0.20684943639291442,
+           'yBias': 1.1235090030742216}]]
+        camera = np.array([[ 1.3441567e+03, -2.1723846e+04,  1.7496496e+04],
+                           [ 6.5500000e+03,  3.9750000e+03,  5.6750000e+03],
+                           [ 3.6606243e-01, -4.4908229e-01, -8.1506038e-01]], dtype=np.float32)
         size_limit_3d = [256,256,256]
         self.itk_viewer = view(image=self._image,
                                label_map=self._label_map,
                                opacity_gaussians=opacity_gaussians,
-                               label_map_blend=0.8,
+                               label_map_blend=0.65,
                                camera=camera,
                                ui_collapsed=True,
+                               shadow=False,
                                size_limit_3d=size_limit_3d,
-                               background=(0.1,)*3,
+                               background=(0.0,)*3,
                                gradient_opacity=0.1)
         # Todo: initialization should work
         self.itk_viewer.opacity_gaussians = opacity_gaussians
         self.itk_viewer.rotate = rotate
+        self.itk_viewer.label_map_blend = 0.65
 
         mode_buttons = RadioButtons(options=['x', 'y', 'z', 'v'], value='v', description='View mode:')
         link((mode_buttons, 'value'), (self.itk_viewer, 'mode'))
 
-        rotate_checkbox = Checkbox(value=False, description='Rotate')
+        rotate_checkbox = Checkbox(value=rotate, description='Rotate')
         link((rotate_checkbox, 'value'), (self.itk_viewer, 'rotate'))
         viewer_controls = HBox([mode_buttons, rotate_checkbox])
+
         viewer = VBox([self.itk_viewer, viewer_controls])
 
         children = [viewer]
+
+        self._validating_allen_ids = False
+        self._validating_acronyms = False
+        self._validating_tree = False
+
         self.tree_widget = None
         if tree is not None:
-            self.tree_widget = IPyTreeWidget(structure_graph)
-            children.append(self.tree_widget)
+            if tree == 'ipytree':
+                self.tree_widget = IPyTreeWidget(structure_graph)
+                children.append(self.tree_widget)
+                self.tree_widget.observe(self._ipytree_on_selected_change, names=['selected_nodes'])
+                def open_parent(node):
+                    if hasattr(node, 'parent_structure_id') and \
+                            node.parent_structure_id in self.tree_widget.allen_id_to_node:
+                        parent = self.tree_widget.allen_id_to_node[node.parent_structure_id]
+                        open_parent(parent)
+                    else:
+                        node.opened = True
+
+                self.last_selected_tree_nodes = []
+                def ipytree_on_allen_ids_changed(change):
+                    self._validating_tree = True
+                    for node in self.last_selected_tree_nodes:
+                        node.selected = False
+                    tree_nodes = [self.tree_widget.allen_id_to_node[allen_id] for allen_id in change.new]
+                    for node in tree_nodes:
+                        open_parent(node)
+                        node.selected = True
+                        node.opened = True
+                    self.last_selected_tree_nodes = tree_nodes
+                    self._validating_tree = False
+                self.observe(ipytree_on_allen_ids_changed, names='selected_allen_ids')
+            else:
+                raise RuntimeError('Invalid tree type')
+
+        self.labels = np.unique(self.itk_viewer.rendered_label_map)
+
 
         super(CCFWidget, self).__init__(children, **kwargs)
+
+    def _ipytree_on_selected_change(self, change):
+        allen_ids = [node.allen_id for node in self.tree_widget.selected_nodes]
+        if not self._validating_tree:
+            self.selected_allen_ids = allen_ids
+        self.tree_widget.layout.width = '40%'
+
+    @validate('selected_allen_ids')
+    def _validate_selected_allen_ids(self, proposal):
+        self._validating_allen_ids = True
+        allen_ids = proposal['value']
+        self._highlight_allen_ids(allen_ids)
+        acronyms = [allen_id_to_acronym[allen_id] for allen_id in allen_ids]
+        if not self._validating_acronyms and \
+            not self.selected_acronyms == acronyms:
+            self.selected_acronyms = acronyms
+        self._validating_allen_ids = False
+        return allen_ids
+
+    @validate('selected_acronyms')
+    def _validate_selected_acronyms(self, proposal):
+        self._validating_acronyms = True
+        acronyms = proposal['value']
+        allen_ids = [acronym_to_allen_id[acronym] for acronym in acronyms]
+        if not self._validating_allen_ids and \
+            not self.selected_allen_ids == allen_ids:
+            self.selected_allen_ids = allen_ids
+        self._validating_acronyms = False
+        return acronyms
+
+    def _highlight_allen_ids(self, allen_ids):
+        weights = np.ones((len(self.labels),), dtype=np.float32)*self.off_weight
+        # Background
+        weights[0] = 0.0
+        for allen_id in allen_ids:
+            labels_for_id = labels_for_allen_id(allen_id)
+            weights[labels_for_id] = self.on_weight
+
+        self.itk_viewer.label_map_weights = weights

--- a/examples/StructureTreeNavigation.ipynb
+++ b/examples/StructureTreeNavigation.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from ipywidgets import SelectMultiple, HBox, VBox\n",
+    "\n",
     "from ccfwidget import CCFWidget"
    ]
   },
@@ -17,12 +19,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "71b3877e90a843fda88087475eb43fe6",
+       "model_id": "2cf4475ade6d42d09e0ee81d27fc4dc6",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "CCFWidget(children=(VBox(children=(Viewer(background=(0.1, 0.1, 0.1), camera=array([[-1.9388698e+02, -6.045237…"
+       "CCFWidget(children=(VBox(children=(Viewer(background=(0.0, 0.0, 0.0), camera=array([[ 1.3441567e+03, -2.172384…"
       ]
      },
      "metadata": {},
@@ -30,8 +32,17 @@
     }
    ],
    "source": [
-    "ccf = CCFWidget(rotate=True)\n",
+    "ccf = CCFWidget(tree='ipytree', rotate=True)\n",
     "ccf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ccf.selected_allen_ids = [623, 313]"
    ]
   },
   {
@@ -40,9 +51,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccf = CCFWidget(tree='ipytree')\n",
-    "ccf"
+    "ccf.selected_allen_ids"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ccf.selected_acronyms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Used to probe or set the highlighted structures.

@bendichter @scottittenburg @brianhhu please take a look.

You can probe / set / observe `ccf.selected_acronyms` or `ccf.selected_allen_ids`, and they are kept is sync. `selected_allen_ids` is the source of truth, kept independent of the ipytree so we can work without the tree and have alternative tree visualizations.

Checking the visual cortex structures, I think there may be errors in the data mapping to the atlas. I will check into regenerating these with the Structure Graph data.

![CCFWidgetLong](https://user-images.githubusercontent.com/25432/84573178-d9c71e80-ad6c-11ea-9814-c465ce10172f.gif)
  