### PR TITLE
Fix marker_opacities initialization

### DIFF
--- a/ccfwidget/widget_ccf.py
+++ b/ccfwidget/widget_ccf.py
@@ -205,6 +205,8 @@ class CCFWidget(HBox):
         self.markers = markers
         if marker_sizes:
             self.marker_sizes = marker_sizes
+        if marker_opacities:
+            self.marker_opacities = marker_opacities
         if marker_colors:
             self.marker_colors = marker_colors
 


### PR DESCRIPTION
Currently, marker_opacities is not initialized if passed to CCFWidget upon initialization. This fixes it by following the pattern for marker_sizes and marker_colors.