### PR TITLE
Fix in-place modification of markers by itk_viewer

### DIFF
--- a/ccfwidget/widget_ccf.py
+++ b/ccfwidget/widget_ccf.py
@@ -123,7 +123,7 @@ class CCFWidget(HBox):
                                label_image=self._label_image,
                                opacity_gaussians=opacity_gaussians,
                                label_image_blend=0.65,
-                               point_sets=markers,
+                               point_sets=markers.copy(),
                                camera=camera,
                                ui_collapsed=True,
                                shadow=False,


### PR DESCRIPTION
Currently, passing in a list of markers at initialization to CCFWidget modifies this list in-place, returning a vtk object instead. This may be surprising to the user, and is different behavior when setting markers after initialization, e.g using ccf.markers = markers, which does not do this modification in-place. This creates a copy of markers at initialization instead.