### PR TITLE
[MNT] - Update fsspec requirement for http

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.5"
 requires = [
   "dask",
-  "fsspec",
+  "fsspec[http]",
   "ipytree",
   "itkwidgets >=0.30.1",
   "toolz",


### PR DESCRIPTION
The `fsspec` dependency here is used for `implementations.http`, which in the context of `fsspec`, requires the extra / optional dependencies of [aiohttp, requiests] (see [fsspec http code](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/http.py) and [fsspec setup.py](https://github.com/fsspec/filesystem_spec/blob/master/setup.py)). 

Based on this, to get cffwidget to install fsspec with the extra dependencies it requires should use the 'http' extra flag here, otherwise, cffwidget throws can throw module not found error for aiohttp if it ends up missing. 